### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -6,6 +6,6 @@ module.exports = function(app, sequelize) {
     fs.readdirSync(__dirname)
         .filter(file => file.slice(-3) === '.js')
         .filter(file => file !== 'index.js')
-        .map(file => file.substr(0, file.indexOf('.')))
+        .map(file => file.slice(0, file.indexOf('.')))
         .map(name => require(`./${name}`)(app, sequelize));
 };


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.